### PR TITLE
docs(readme): 修复 README 模块路径与 go.mod 对齐 (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,48 +35,47 @@ A lightweight, high-performance Go authentication and authorization framework, i
 
 ```bash
 # Import only the framework integration (includes core + stputil automatically)
-go get github.com/sa-tokens/sa-token-go/integrations/gin@latest    # Gin framework
+go get github.com/click33/sa-token-go/integrations/gin@latest    # Gin framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/echo@latest   # Echo framework
+go get github.com/click33/sa-token-go/integrations/echo@latest   # Echo framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/fiber@latest  # Fiber framework
+go get github.com/click33/sa-token-go/integrations/fiber@latest  # Fiber framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/chi@latest    # Chi framework
+go get github.com/click33/sa-token-go/integrations/chi@latest    # Chi framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/gf@latest     # GoFrame framework
+go get github.com/click33/sa-token-go/integrations/gf@latest     # GoFrame framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/kratos@latest   # Kratos framework
+go get github.com/click33/sa-token-go/integrations/kratos@latest   # Kratos framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/hertz@latest  # Hertz framework
+go get github.com/click33/sa-token-go/integrations/hertz@latest  # Hertz framework
 # or
-go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris framework
-```
+go get github.com/click33/sa-token-go/integrations/iris@latest   # Iris framework
 
 # Storage module (choose one)
-go get github.com/sa-tokens/sa-token-go/storage/memory@latest # Memory storage (dev)
-go get github.com/sa-tokens/sa-token-go/storage/redis@latest  # Redis storage (prod)
+go get github.com/click33/sa-token-go/storage/memory@latest # Memory storage (dev)
+go get github.com/click33/sa-token-go/storage/redis@latest  # Redis storage (prod)
 ```
 
 #### Option 2: Separate Import
 
 ```bash
 # Core modules
-go get github.com/sa-tokens/sa-token-go/core@vlatest 
-go get github.com/sa-tokens/sa-token-go/stputil@vlatest 
+go get github.com/click33/sa-token-go/core@latest 
+go get github.com/click33/sa-token-go/stputil@latest 
 
 # Storage module (choose one)
-go get github.com/sa-tokens/sa-token-go/storage/memory@latest # Memory storage (dev)
-go get github.com/sa-tokens/sa-token-go/storage/redis@latest  # Redis storage (prod)
+go get github.com/click33/sa-token-go/storage/memory@latest # Memory storage (dev)
+go get github.com/click33/sa-token-go/storage/redis@latest  # Redis storage (prod)
 
 # Framework integration (optional)
-go get github.com/sa-tokens/sa-token-go/integrations/gin@latest    # Gin framework
-go get github.com/sa-tokens/sa-token-go/integrations/echo@latest   # Echo framework
-go get github.com/sa-tokens/sa-token-go/integrations/fiber@latest  # Fiber framework
-go get github.com/sa-tokens/sa-token-go/integrations/chi@latest    # Chi framework
-go get github.com/sa-tokens/sa-token-go/integrations/gf@latest     # GoFrame framework
-go get github.com/sa-tokens/sa-token-go/integrations/kratos@latest # Kratos framework
-go get github.com/sa-tokens/sa-token-go/integrations/hertz@latest  # Hertz framework
-go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris framework
+go get github.com/click33/sa-token-go/integrations/gin@latest    # Gin framework
+go get github.com/click33/sa-token-go/integrations/echo@latest   # Echo framework
+go get github.com/click33/sa-token-go/integrations/fiber@latest  # Fiber framework
+go get github.com/click33/sa-token-go/integrations/chi@latest    # Chi framework
+go get github.com/click33/sa-token-go/integrations/gf@latest     # GoFrame framework
+go get github.com/click33/sa-token-go/integrations/kratos@latest # Kratos framework
+go get github.com/click33/sa-token-go/integrations/hertz@latest  # Hertz framework
+go get github.com/click33/sa-token-go/integrations/iris@latest   # Iris framework
 ```
 
 ### ⚡ Minimal Usage (One-line Initialization)
@@ -85,9 +84,9 @@ go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris framew
 package main
 
 import (
-    "github.com/sa-tokens/sa-token-go/core"
-    "github.com/sa-tokens/sa-token-go/stputil"
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    "github.com/click33/sa-token-go/core"
+    "github.com/click33/sa-token-go/stputil"
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func init() {
@@ -304,9 +303,9 @@ package context
 import (
 	"strings"
 
-	"github.com/sa-tokens/sa-token-go/core/adapter"
-	"github.com/sa-tokens/sa-token-go/core/config"
-	"github.com/sa-tokens/sa-token-go/core/manager"
+	"github.com/click33/sa-token-go/core/adapter"
+	"github.com/click33/sa-token-go/core/config"
+	"github.com/click33/sa-token-go/core/manager"
 )
 
 const bearerPrefix = "Bearer "
@@ -382,8 +381,8 @@ func ReadTokenFromRequest(ctx adapter.RequestContext, mgr *manager.Manager) stri
 ```go
 import (
     "github.com/gin-gonic/gin"
-    sagin "github.com/sa-tokens/sa-token-go/integrations/gin"  // Only this import needed!
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    sagin "github.com/click33/sa-token-go/integrations/gin"  // Only this import needed!
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func main() {
@@ -439,7 +438,7 @@ func main() {
 **Usage example:**
 
 ```go
-import sagin "github.com/sa-tokens/sa-token-go/integrations/gin"
+import sagin "github.com/click33/sa-token-go/integrations/gin"
 
 func main() {
     r := gin.Default()
@@ -476,8 +475,8 @@ func main() {
 import (
     "github.com/gogf/gf/v2/frame/g"
     "github.com/gogf/gf/v2/net/ghttp"
-    sagf "github.com/sa-tokens/sa-token-go/integrations/gf"  // Only this import needed!
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    sagf "github.com/click33/sa-token-go/integrations/gf"  // Only this import needed!
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func main() {
@@ -514,27 +513,27 @@ func main() {
 
 ```go
 // Echo
-import saecho "github.com/sa-tokens/sa-token-go/integrations/echo"
+import saecho "github.com/click33/sa-token-go/integrations/echo"
 e.GET("/user", saecho.CheckLogin(), handler)
 
 // Fiber
-import safiber "github.com/sa-tokens/sa-token-go/integrations/fiber"
+import safiber "github.com/click33/sa-token-go/integrations/fiber"
 app.Get("/user", safiber.CheckLogin(), handler)
 
 // Chi
-import sachi "github.com/sa-tokens/sa-token-go/integrations/chi"
+import sachi "github.com/click33/sa-token-go/integrations/chi"
 r.Get("/user", sachi.CheckLogin(), handler)
 
 // Kratos
-import sakratos "github.com/sa-tokens/sa-token-go/integrations/kratos"
+import sakratos "github.com/click33/sa-token-go/integrations/kratos"
 // Use Plugin.Server() as middleware
 
 // Hertz
-import sahertz "github.com/sa-tokens/sa-token-go/integrations/hertz"
+import sahertz "github.com/click33/sa-token-go/integrations/hertz"
 h.GET("/user", sahertz.CheckLogin(), handler)
 
 // Iris
-import sairis "github.com/sa-tokens/sa-token-go/integrations/iris"
+import sairis "github.com/click33/sa-token-go/integrations/iris"
 app.Get("/user", sairis.CheckLogin(), handler)
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -41,47 +41,47 @@
 
 ```bash
 # 只导入框架集成包（自动包含 core + stputil）
-go get github.com/sa-tokens/sa-token-go/integrations/gin@latest    # Gin框架
+go get github.com/click33/sa-token-go/integrations/gin@latest    # Gin框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/echo@latest   # Echo框架
+go get github.com/click33/sa-token-go/integrations/echo@latest   # Echo框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/fiber@latest  # Fiber框架
+go get github.com/click33/sa-token-go/integrations/fiber@latest  # Fiber框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/chi@latest    # Chi框架
+go get github.com/click33/sa-token-go/integrations/chi@latest    # Chi框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/gf@latest     # GoFrame框架
+go get github.com/click33/sa-token-go/integrations/gf@latest     # GoFrame框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/kratos@latest # Kratos框架
+go get github.com/click33/sa-token-go/integrations/kratos@latest # Kratos框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/hertz@latest  # Hertz框架
+go get github.com/click33/sa-token-go/integrations/hertz@latest  # Hertz框架
 # 或
-go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris框架
+go get github.com/click33/sa-token-go/integrations/iris@latest   # Iris框架
 
 # 存储模块（选一个）
-go get github.com/sa-tokens/sa-token-go/storage/memory@latest # 内存存储（开发）
-go get github.com/sa-tokens/sa-token-go/storage/redis@latest  # Redis存储（生产）
+go get github.com/click33/sa-token-go/storage/memory@latest # 内存存储（开发）
+go get github.com/click33/sa-token-go/storage/redis@latest  # Redis存储（生产）
 ```
 
 #### 方式二：分开导入
 
 ```bash
 # 核心模块
-go get github.com/sa-tokens/sa-token-go/core@vlatest 
-go get github.com/sa-tokens/sa-token-go/stputil@vlatest 
+go get github.com/click33/sa-token-go/core@latest 
+go get github.com/click33/sa-token-go/stputil@latest 
 
 # 存储模块（选一个）
-go get github.com/sa-tokens/sa-token-go/storage/memory@latest # 内存存储（开发）
-go get github.com/sa-tokens/sa-token-go/storage/redis@latest  # Redis存储（生产）
+go get github.com/click33/sa-token-go/storage/memory@latest # 内存存储（开发）
+go get github.com/click33/sa-token-go/storage/redis@latest  # Redis存储（生产）
 
 # 框架集成（可选）
-go get github.com/sa-tokens/sa-token-go/integrations/gin@latest    # Gin框架
-go get github.com/sa-tokens/sa-token-go/integrations/echo@latest   # Echo框架
-go get github.com/sa-tokens/sa-token-go/integrations/fiber@latest  # Fiber框架
-go get github.com/sa-tokens/sa-token-go/integrations/chi@latest    # Chi框架
-go get github.com/sa-tokens/sa-token-go/integrations/gf@latest     # GoFrame框架
-go get github.com/sa-tokens/sa-token-go/integrations/kratos@latest # Kratos框架
-go get github.com/sa-tokens/sa-token-go/integrations/hertz@latest  # Hertz框架
-go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris框架
+go get github.com/click33/sa-token-go/integrations/gin@latest    # Gin框架
+go get github.com/click33/sa-token-go/integrations/echo@latest   # Echo框架
+go get github.com/click33/sa-token-go/integrations/fiber@latest  # Fiber框架
+go get github.com/click33/sa-token-go/integrations/chi@latest    # Chi框架
+go get github.com/click33/sa-token-go/integrations/gf@latest     # GoFrame框架
+go get github.com/click33/sa-token-go/integrations/kratos@latest # Kratos框架
+go get github.com/click33/sa-token-go/integrations/hertz@latest  # Hertz框架
+go get github.com/click33/sa-token-go/integrations/iris@latest   # Iris框架
 ```
 
 ### ⚡ 超简洁使用（一行初始化）
@@ -90,9 +90,9 @@ go get github.com/sa-tokens/sa-token-go/integrations/iris@latest   # Iris框架
 package main
 
 import (
-    "github.com/sa-tokens/sa-token-go/core"
-    "github.com/sa-tokens/sa-token-go/stputil"
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    "github.com/click33/sa-token-go/core"
+    "github.com/click33/sa-token-go/stputil"
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func init() {
@@ -309,9 +309,9 @@ package context
 import (
 	"strings"
 
-	"github.com/sa-tokens/sa-token-go/core/adapter"
-	"github.com/sa-tokens/sa-token-go/core/config"
-	"github.com/sa-tokens/sa-token-go/core/manager"
+	"github.com/click33/sa-token-go/core/adapter"
+	"github.com/click33/sa-token-go/core/config"
+	"github.com/click33/sa-token-go/core/manager"
 )
 
 const bearerPrefix = "Bearer "
@@ -387,8 +387,8 @@ func ReadTokenFromRequest(ctx adapter.RequestContext, mgr *manager.Manager) stri
 ```go
 import (
     "github.com/gin-gonic/gin"
-    sagin "github.com/sa-tokens/sa-token-go/integrations/gin"  // 只需这一个导入！
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    sagin "github.com/click33/sa-token-go/integrations/gin"  // 只需这一个导入！
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func main() {
@@ -444,7 +444,7 @@ func main() {
 **使用示例：**
 
 ```go
-import sagin "github.com/sa-tokens/sa-token-go/integrations/gin"
+import sagin "github.com/click33/sa-token-go/integrations/gin"
 
 func main() {
     r := gin.Default()
@@ -481,8 +481,8 @@ func main() {
 import (
     "github.com/gogf/gf/v2/frame/g"
     "github.com/gogf/gf/v2/net/ghttp"
-    sagf "github.com/sa-tokens/sa-token-go/integrations/gf"  // 只需这一个导入！
-    "github.com/sa-tokens/sa-token-go/storage/memory"
+    sagf "github.com/click33/sa-token-go/integrations/gf"  // 只需这一个导入！
+    "github.com/click33/sa-token-go/storage/memory"
 )
 
 func main() {
@@ -519,27 +519,27 @@ func main() {
 
 ```go
 // Echo
-import saecho "github.com/sa-tokens/sa-token-go/integrations/echo"
+import saecho "github.com/click33/sa-token-go/integrations/echo"
 e.GET("/user", saecho.CheckLogin(), handler)
 
 // Fiber
-import safiber "github.com/sa-tokens/sa-token-go/integrations/fiber"
+import safiber "github.com/click33/sa-token-go/integrations/fiber"
 app.Get("/user", safiber.CheckLogin(), handler)
 
 // Chi
-import sachi "github.com/sa-tokens/sa-token-go/integrations/chi"
+import sachi "github.com/click33/sa-token-go/integrations/chi"
 r.Get("/user", sachi.CheckLogin(), handler)
 
 // Kratos
-import sakratos "github.com/sa-tokens/sa-token-go/integrations/kratos"
+import sakratos "github.com/click33/sa-token-go/integrations/kratos"
 // 使用 Plugin.Server() 作为中间件
 
 // Hertz
-import sahertz "github.com/sa-tokens/sa-token-go/integrations/hertz"
+import sahertz "github.com/click33/sa-token-go/integrations/hertz"
 h.GET("/user", sahertz.CheckLogin(), handler)
 
 // Iris
-import sairis "github.com/sa-tokens/sa-token-go/integrations/iris"
+import sairis "github.com/click33/sa-token-go/integrations/iris"
 app.Get("/user", sairis.CheckLogin(), handler)
 ```
 


### PR DESCRIPTION
## 概要

修复 `README.md` 和 `README_zh.md` 里失效的 `go get` 命令。README 写的是 `github.com/sa-tokens/sa-token-go/*`,但 go.mod 实际声明的路径是 `github.com/click33/sa-token-go/*`,所以按文档执行 `go get` 会报 mismatched module path 错误。

Closes #45。

## 改动

- **模块路径**:将所有安装和导入示例里的 `github.com/sa-tokens/sa-token-go/*` 替换为 `github.com/click33/sa-token-go/*`,覆盖中英文两个 README。
- **`@vlatest` typo**:修正为 `@latest`(共 4 处)。
- **README.md 错位的 fence**:多了一个 ```,提前关闭了 bash 代码块,把 Storage module 那一段挤出代码块外。README_zh.md 的同位置原本是对的。

## 不在本次范围

- **不动 `go.mod` 的模块路径**。将 `click33` 改为 `sa-tokens` 是 breaking change,会影响所有现存依赖者,需要 major-version bump。把 README 改成跟当前 `go.mod` 对齐是非破坏性的修复方式。
- **GitHub issues 链接保留为 `sa-tokens/sa-token-go/issues`**,因为那是当前仓库的实际地址。

## 测试清单

- [x] README 里所有 `go get github.com/click33/sa-token-go/...` 命令都和对应 `go.mod` 的 `module` 行匹配
- [x] 安装/导入示例里没有残留 `sa-tokens/sa-token-go` 引用(只剩 issues 链接,是有意保留)
- [x] 没有残留的 `@vlatest`
- [x] `README.md` 代码块渲染正确(Storage 段落在 bash 代码块内)